### PR TITLE
Assume int responses aren't errors

### DIFF
--- a/mailsnake/mailsnake.py
+++ b/mailsnake/mailsnake.py
@@ -52,7 +52,7 @@ class MailSnake(object):
         except json.JSONDecodeError, e:
             raise ParseException(e.reason)
 
-        if not isinstance(rsp, (bool, basestring)) and 'error' in rsp and 'code' in rsp:
+        if not isinstance(rsp, (int, bool, basestring)) and 'error' in rsp and 'code' in rsp:
             try:
                 Err = exception_for_code(rsp['code'])
             except KeyError:


### PR DESCRIPTION
An update to 43642a6cd8.  The campaignSegmentTest call returns
an integer (number of subscribers in a segment).

This should probably be 'isinstance(rsp, dict)' but I did not
have an opportunity to try that yet.
