### PR TITLE
Streamed response support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,41 @@ mapi = MailSnake('YOUR MANDRILL API KEY', api='mandrill')
 mapi.messages.send(message={'html':'email html', 'subject':'email subject', 'from_email':'from@example.com', 'from_name':'From Name', 'to':[{'email':'to@example.com', 'name':'To Name'}]}) # returns 'PONG!'
 ```
 
+Additional Request Options
+--------------------------
+
+MailSnake uses [Requests](http://docs.python-requests.org/en/v1.0.0/) for
+HTTP. If you require more control over how your request is made,
+you may supply a dictionary as the value of `requests_opts` when
+constructing an instance of `MailSnake`. This will be passed through (as
+kwargs) to `requests.post()`. See the next section for an example.
+
+Streamed Responses
+------------------
+
+Since responses from the MailChimp Export API can be quite large, it is
+helpful to be able to consume them in a streamed fashion. If you supply
+`requests_opts={'stream': True}` when calling MailSnake, a generator is
+returned that deserializes and yields each line of the streamed response
+as it arrives:
+
+```python
+from mailsnake import MailSnake
+
+opts = {'stream': True}
+export = MailSnake('YOURAPIKEY', api='export', requests_opts=opts)
+resp = export.list(id='YOURLISTID')
+
+lines = 0
+for list_member in resp():
+    if lines > 0: # skip header row
+        print list_member
+    lines += 1
+```
+
+If you are using Requests < 1.0.0, supply `{'prefetch': False}` instead of
+`{'stream': True}`.
+
 Note
 ----
 

--- a/mailsnake/mailsnake.py
+++ b/mailsnake/mailsnake.py
@@ -1,6 +1,7 @@
 """ MailSnake """
 import collections
 import requests
+import types
 from requests.compat import basestring
 
 try:
@@ -24,9 +25,11 @@ class MailSnake(object):
                  apikey='',
                  extra_params=None,
                  api='api',
-                 api_section=''):
-        """
-            Cache API key and address.
+                 api_section='',
+                 requests_opts={}):
+        """Cache API key and address. For additional control over how
+        requests are made, supply a dictionary for requests_opts. This will
+        be passed through to requests.post() as kwargs.
         """
         self.apikey = apikey
 
@@ -60,6 +63,12 @@ class MailSnake(object):
         }
         self.api_url = 'https://%s%s%s.com/%s' % api_info[api]
 
+        self.requests_opts = requests_opts
+        # Handle both prefetch=False (Requests < 1.0.0)
+        prefetch = requests_opts.get('prefetch', True)
+        # and stream=True (Requests >= 1.0.0) for response streaming
+        self.stream = requests_opts.get('stream', not prefetch)
+
     def __repr__(self):
         if self.api == 'api':
             api = 'API v3'
@@ -71,6 +80,11 @@ class MailSnake(object):
         return '<MailSnake %s: %s>' % (api, self.apikey)
 
     def call(self, method, params=None):
+        """Call the appropriate MailChimp API method with supplied
+        params. If response streaming is enabled, return a generator
+        that yields one line of deserialized JSON at a time, otherwise
+        simply deserialize and return the entire JSON response body.
+        """
         url = self.api_url
         if self.api == 'mandrill':
             url += (self.api_section + '/' + method + '.json')
@@ -95,10 +109,15 @@ class MailSnake(object):
 
         try:
             if self.api == 'export':
-                req = requests.post(
-                    url, params=flatten_data(data), headers=headers)
+                req = requests.post(url,
+                                    params=flatten_data(data),
+                                    headers=headers,
+                                    **self.requests_opts)
             else:
-                req = requests.post(url, data=data, headers=headers)
+                req = requests.post(url,
+                                    data=data,
+                                    headers=headers,
+                                    **self.requests_opts)
         except requests.exceptions.RequestException as e:
             raise HTTPRequestException(e.message)
 
@@ -106,15 +125,23 @@ class MailSnake(object):
             raise HTTPRequestException(req.status_code)
 
         try:
-            if self.api == 'export' and req.text.find('\n') > -1:
+            if self.stream:
+                def stream():
+                    for line in req.iter_lines():
+                        # Handle byte arrays in Python 3
+                        line = line.decode('utf-8')
+                        if line:
+                            yield json.loads(line)
+                rsp = stream
+            elif self.api == 'export' and req.text.find('\n') > -1:
                 rsp = [json.loads(i) for i in req.text.split('\n')[0:-1]]
             else:
                 rsp = json.loads(req.text)
         except ValueError as e:
             raise ParseException(e.message)
 
-        if not isinstance(rsp, (int, bool, basestring)) and \
-                'error' in rsp and 'code' in rsp:
+        types_ = int, bool, basestring, types.FunctionType
+        if not isinstance(rsp, types_) and 'error' in rsp and 'code' in rsp:
             try:
                 Err = exception_for_code(rsp['code'])
             except KeyError:


### PR DESCRIPTION
Instance-level reimplementation of [#15](https://github.com/michaelhelmick/python-mailsnake/pull/15)

Adds support for streamed responses (potentially very large ones from the export API, for example) by modifying `MailSnake.__init__()` to accept a new kwarg `requests_opts` that is passed through to `requests.post()` on each request. If `'stream': True` or `'prefetch': False` is present in `requests_opts`, `MailSnake.call()` returns a generator that yields each (deserialized) line as it arrives.

Tested in Python 2.7.3 and 3.2.3 against Requests 0.14.2 and 1.0.3.
