### PR TITLE
bump version to 1.6.3

### DIFF
--- a/mailsnake/mailsnake.py
+++ b/mailsnake/mailsnake.py
@@ -129,8 +129,6 @@ class MailSnake(object):
                 'status_code': req.status_code,
                 'reason': req.reason,
                 'url': url,
-                'params': flatten_data(data),
-                'options': self.requests_opts,
             }))
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ elif _ver[0] == 3:
 
 setup(
     name='mailsnake',
-    version='1.6.2',
+    version='1.6.3',
     description='MailChimp API v1.3, STS, Export, Mandrill wrapper for Python.',
     long_description=open('README.rst').read(),
     author='John-Kim Murphy',


### PR DESCRIPTION
Update version number according previous PR https://github.com/michaelhelmick/python-mailsnake/pull/24 
Without version update there is no way to upgrade mailsnake automatically. Setuptools with dependency_link pointing to github will omit this upgrade.