### PR TITLE
Remove simplejson requirement.

### DIFF
--- a/mailsnake/mailsnake.py
+++ b/mailsnake/mailsnake.py
@@ -1,21 +1,10 @@
 """ MailSnake """
 import collections
+import json
+
 import requests
 import types
 from requests.compat import basestring
-
-try:
-    import simplejson as json
-except ImportError:
-    try:
-        import json
-    except ImportError:
-        try:
-            from django.utils import simplejson as json
-        except ImportError:
-            raise ImportError('A json library is required to use ' + \
-                             'this python library. Lol, yay for ' + \
-                             'being verbose. ;)')
 
 from .exceptions import *
 

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,6 @@
 #!/usr/bin/env python
 
-import sys
 from setuptools import setup, find_packages
-
-# dep sugar.
-_ver = sys.version_info
-
-if _ver[0] == 2:
-    dep = ['simplejson', 'requests']
-elif _ver[0] == 3:
-    dep = ['requests']
 
 setup(
     name='mailsnake',
@@ -22,7 +13,7 @@ setup(
     download_url='http://pypi.python.org/pypi/mailsnake/',
     keywords='mailsnake mailchimp api wrapper export mandrill sts 1.3 p3k',
     zip_safe=True,
-    install_requires=dep,
+    install_requires=['requests'],
     py_modules=['mailsnake'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
All versions of python come with a capable json package in the standard library. There is no need (IMHO) to require simplejson.

At the very least, you could make it optional: the first commit does this. Otherwise, you automatically install a package in python 2, which isn't really a true requirement.

(I'm happy to see a rationale for requiring simplejson over json though!)
